### PR TITLE
2002/Refactoring: libP2p changed to a publisher and subscriber method

### DIFF
--- a/network/node.go
+++ b/network/node.go
@@ -1,70 +1,116 @@
 package network
 
 import (
+	"bufio"
 	"context"
+	"crypto/rand"
 	"fmt"
-	"strings"
 
 	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/multiformats/go-multiaddr"
 )
 
-func createSourceNode() host.Host {
-	node, err := libp2p.New()
+/*
+	func createSourceNode() host.Host {
+		node, err := libp2p.New()
+		if err != nil {
+			panic(err)
+		}
+		return node
+	}
+
+	func createTargetNode(multiAddr multiaddr.Multiaddr, privKey crypto.PrivKey) (host.Host, error) {
+		node, err := libp2p.New(
+			libp2p.ListenAddrs(multiAddr),
+			libp2p.Identity(privKey),
+		)
+		if err != nil {
+			return nil, err
+		}
+		return node, nil
+	}
+
+	func connectToTargetNode(sourceNode host.Host, targetNode host.Host) error {
+		targetNodeAddressInfo := host.InfoFromHost(targetNode)
+		err := sourceNode.Connect(context.Background(), *targetNodeAddressInfo)
+		return err
+	}
+
+	func countSourceNodePeers(sourceNode host.Host) int {
+		return len(sourceNode.Network().Peers())
+	}
+
+	func printNodeID(node host.Host) {
+		println(fmt.Sprintf("Node ID: %s", node.ID().String()))
+	}
+
+	func printNodeAddress(node host.Host) {
+		addressesString := make([]string, 0)
+		for _, address := range node.Addrs() {
+			addressesString = append(addressesString, address.String())
+		}
+		println(fmt.Sprintf("Multiaddresses: %s", strings.Join(addressesString, ",")))
+
+}
+*/
+func P2p(publisher bool) {
+
+	fmt.Println("Starting the node")
+	ctx := context.Background()
+
+	// use out keyPair is not possible because the privKey must be the type crypto.PrivKey
+
+	r := rand.Reader
+	privKey, _, err := crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, r)
+
 	if err != nil {
+		fmt.Println("Error generating key pair")
 		panic(err)
 	}
-	return node
-}
+	sourceMultiAddr, err := multiaddr.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
 
-func createTargetNode() host.Host {
-	node, err := libp2p.New(
-		libp2p.ListenAddrStrings(
-			"/ip4/0.0.0.0/tcp/8007",
-		),
+	if err != nil {
+		fmt.Println("Error creating multiaddr")
+		panic(err)
+	}
+
+	host, err := libp2p.New(
+		libp2p.ListenAddrs(sourceMultiAddr),
+		libp2p.Identity(privKey),
 	)
 	if err != nil {
+		fmt.Println("Error creating node")
 		panic(err)
 	}
-	return node
-}
+	host = CreateStreamHandler(host, publisher)
+	peerChan := InitDMNS(host)
 
-func connectToTargetNode(sourceNode host.Host, targetNode host.Host) {
-	targetNodeAddressInfo := host.InfoFromHost(targetNode)
-	err := sourceNode.Connect(context.Background(), *targetNodeAddressInfo)
-	if err != nil {
-		panic(err)
+	for {
+		peer := <-peerChan
+		fmt.Println("Found peer:", peer, "connecting")
+
+		if err := host.Connect(ctx, peer); err != nil {
+			fmt.Println("Connection failed:", err)
+			continue
+
+		}
+
+		stream, err := host.NewStream(ctx, peer.ID, protocol.ID("/super-protocol/1.0.0"))
+
+		if err != nil {
+			fmt.Println("Stream open failed:", err)
+			continue
+		} else {
+			rw := bufio.NewReadWriter(bufio.NewReader(stream), bufio.NewWriter(stream))
+			if publisher {
+				go WriteData(rw)
+			} else {
+				go ReadData(rw)
+			}
+			fmt.Println("Connected to:", peer)
+		}
 	}
-}
 
-func countSourceNodePeers(sourceNode host.Host) int {
-	return len(sourceNode.Network().Peers())
-}
-
-func printNodeID(node host.Host) {
-	println(fmt.Sprintf("Node ID: %s", node.ID().String()))
-}
-
-func printNodeAddress(node host.Host) {
-	addressesString := make([]string, 0)
-	for _, address := range node.Addrs() {
-		addressesString = append(addressesString, address.String())
-	}
-	println(fmt.Sprintf("Multiaddresses: %s", strings.Join(addressesString, ",")))
-
-}
-func connectNode() {
-	sourceNode := createSourceNode()
-	println("-- SOURCE NODE INFO --")
-	printNodeID(sourceNode)
-	printNodeAddress(sourceNode)
-
-	targetNode := createTargetNode()
-	println("-- TARGET NODE INFO --")
-	printNodeID(targetNode)
-	printNodeAddress(targetNode)
-
-	connectToTargetNode(sourceNode, targetNode)
-
-	println(fmt.Sprintf("Source node peers: %d", countSourceNodePeers(sourceNode)))
 }

--- a/network/stream.go
+++ b/network/stream.go
@@ -2,82 +2,70 @@ package network
 
 import (
 	"bufio"
-	"context"
+	"fmt"
 	"log"
+	"time"
 
-	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 )
 
-func createNode() host.Host {
-	node, err := libp2p.New()
-	if err != nil {
-		panic(err)
-	}
-
-	return node
+type discoveryNotifee struct {
+	PeerChan chan peer.AddrInfo
 }
 
-func readHelloProtocol(s network.Stream) error {
-	buf := bufio.NewReader(s)
-	message, err := buf.ReadString('\n')
-	if err != nil {
-		return err
-	}
-
-	connection := s.Conn()
-
-	log.Printf("Message from '%s': %s", connection.RemotePeer().String(), message)
-	return nil
+func (n *discoveryNotifee) HandlePeerFound(pi peer.AddrInfo) {
+	n.PeerChan <- pi
 }
 
-func runTargetNode() peer.AddrInfo {
-	log.Printf("Creating target node...")
-	targetNode := createNode()
-	log.Printf("Target node created with ID '%s'", targetNode.ID().String())
+func ReadData(rw *bufio.ReadWriter) {
+	for {
 
-	// TO BE IMPLEMENTED: Set stream handler for the "/hello/1.0.0" protocol
-	targetNode.SetStreamHandler("/hello/1.0.0", func(s network.Stream) {
-		log.Printf("/hello/1.0.0 stream created")
-		err := readHelloProtocol(s)
+		str, err := rw.ReadString('\n')
 		if err != nil {
-			s.Reset()
-		} else {
-			s.Close()
+			fmt.Println("Error reading from buffer")
+			panic(err)
 		}
+		if str != "" {
+			log.Printf("Read data: %s", str)
+		}
+	}
+}
+func WriteData(rw *bufio.ReadWriter) {
+	for {
+
+		time.Sleep(5 * time.Second)
+		str := "Hello from Launchpad!\n"
+		log.Printf("Writing data: %s", str)
+
+		rw.WriteString(str)
+		rw.Flush()
+	}
+}
+func InitDMNS(peerHost host.Host) chan peer.AddrInfo {
+	n := &discoveryNotifee{}
+	n.PeerChan = make(chan peer.AddrInfo)
+	ser := mdns.NewMdnsService(peerHost, "desentralizao", n)
+	if err := ser.Start(); err != nil {
+		panic(err)
+	}
+	return n.PeerChan
+}
+
+func CreateStreamHandler(node host.Host, publisher bool) host.Host {
+	log.Printf("Creating handlers...")
+
+	node.SetStreamHandler("/super-protocol/1.0.0", func(s network.Stream) {
+		log.Printf("Ha llegado carta")
+		rw := bufio.NewReadWriter(bufio.NewReader(s), bufio.NewWriter(s))
+		if publisher {
+			go WriteData(rw)
+		} else {
+			go ReadData(rw)
+		}
+
 	})
-
-	return *host.InfoFromHost(targetNode)
-}
-
-func runSourceNode(targetNodeInfo peer.AddrInfo) {
-	log.Printf("Creating source node...")
-	sourceNode := createNode()
-	log.Printf("Source node created with ID '%s'", sourceNode.ID().String())
-
-	sourceNode.Connect(context.Background(), targetNodeInfo)
-
-	// TO BE IMPLEMENTED: Open stream and send message
-	stream, err := sourceNode.NewStream(context.Background(), targetNodeInfo.ID, "/hello/1.0.0")
-	if err != nil {
-		panic(err)
-	}
-
-	message := "Hello from Launchpad!\n"
-	log.Printf("Sending message...")
-	_, err = stream.Write([]byte(message))
-	if err != nil {
-		panic(err)
-	}
-}
-
-func streamNodes() {
-	ctx, _ := context.WithCancel(context.Background())
-
-	info := runTargetNode()
-	runSourceNode(info)
-
-	<-ctx.Done()
+	return node
 }


### PR DESCRIPTION
## Proposed changes


The network folder was refactored, now is used with a method Publisher and Subscriber to make a PoA consensus algorithm where the Publisher has the authority of make changes in the blockchain and all the Subscribers just can read the info and update his nodes
**Trello Ticket** [here](https://trello.com/c/6WwXmGSO/11-2002-refactoring-libp2p-to-ps)

## Types of changes

What types of changes does your code introduce to this Blockchain?

<!---
Put an `x` in the boxes that apply
--->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added necessary documentation (if appropriate)
- [x] My pull request name and branch name it's with the Trello Ticket format

